### PR TITLE
fix userId_example.html

### DIFF
--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -84,6 +84,9 @@
             {
                 code: 'test-div',
                 sizes: [[300,250],[300,600],[728,90]],
+                mediaTypes: {
+                    banner: {}
+                },
                 bids: [
                     {
                         bidder: 'rubicon',
@@ -128,7 +131,7 @@
                 //         }
                 //     }
                 // },
-                usersync: {
+                userSync: {
                     userIds: [{
                         name: "unifiedId",
                         params: {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
On running `gulp serve` and navigating to **integrationExamples/gpt/userId_example.html?pbjs_debug=true**, one can see prebid initialised but the bids are not generated.
Issue arises due to:-
1. no mediaTypes configuration in adUnit (test-div).
2. `usersync` instead of `userSync` present in setConfig method.

Fixes of these both are available in this pr and results in correct behaviour in terms of userIds in pbjs.getUserIds() and bids in pbjs.adUnits. 
Find the attached console output.
<img width="909" alt="Screenshot 2020-08-14 at 2 54 17 PM" src="https://user-images.githubusercontent.com/36563196/90237837-8e9bbb80-de42-11ea-9fe8-4945c73db4ce.png">

